### PR TITLE
feat: add "mermaid-diagram" CSS class on mermaid Vue component root element

### DIFF
--- a/src/mermaid.js
+++ b/src/mermaid.js
@@ -35,6 +35,7 @@ const Mermaid = {
         }
 
         return h('div', {
+            class: ['mermaid-diagram'],
             domProps: {
                 innerHTML: this.svg,
                 style: 'width: 100%'

--- a/tests/cypress/integration/simple.spec.js
+++ b/tests/cypress/integration/simple.spec.js
@@ -1,4 +1,4 @@
 it('renders diagrams', () => {
     cy.visit('/test-diagrams.html')
-    cy.get('#a-simple-one + div').toMatchImageSnapshot()
+    cy.get('#a-simple-one + .mermaid-diagram').toMatchImageSnapshot()
 })


### PR DESCRIPTION
## Context

I'm currently working on an internal technical documentation based on VuePress and I integrated you plugin to it.

First thank you for it, it works well 💚

I'm just struggling a bit with the styling of the generated graph. I just want to be able to target the parent block with a CSS class to be able to style it a bit (centering, changing fonts...)

## Proposal

That PR just add a custom `mermaid-block` class on the root element of the `Mermaid` component to allow CSS styling on that element.